### PR TITLE
add action to short-tag releases

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -3,6 +3,9 @@ name: pull-request
 on:
   pull_request:
     types: [edited, synchronize, opened, reopened]
+    push:
+      branches:
+        - 'main'
 
 jobs:
   checks:

--- a/.github/workflows/release-short-tag.yaml
+++ b/.github/workflows/release-short-tag.yaml
@@ -1,0 +1,19 @@
+on:
+  release:
+    types: [released]
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create generic version tag based on release tag
+        run: |
+          echo "tag_name=$(echo ${{ github.ref_name }} | sed -E 's/^(v[0-9]+)\.[0-9]+\.[0-9]+$/\1/')" >> $GITHUB_ENV
+      - uses: actions/checkout@v3
+      - name: Create generic tag
+        uses: negz/create-tag@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          git_commit_sha: ${{ github.sha }}
+          version: ${{ env.tag_name }}
+


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Put the GitHub issue number or Jira ticket ID here! -->
Closes #13

## Description
<!-- What does this PR do? Why are we opening it? -->

Creates a short-tag on new releases.

Also run CI pipeline on pushes to main to benefit from sonar-scan

## Important Notes
<!-- Is there anything we need to know while reviewing? -->

For example, if we release v1.0.1, it should create a tag called `v1` pointing at the same commit hash as v1.0.1. It should force-push and overwrite existing tags, so `v1` will always be the latest v1.x.y, `v2` will always be the latest v2.x.y, etc.

## Screenshots

<!-- Got any before / after shots to show off how awesome this change is? -->

Tested on a throw-away repo:
<img width="606" alt="Screen Shot 2023-03-17 at 5 03 12 PM" src="https://user-images.githubusercontent.com/50844842/226074970-43c00260-dd9a-4cda-82fa-a8bd3ffefc2a.png">
<img width="1304" alt="Screen Shot 2023-03-17 at 5 02 59 PM" src="https://user-images.githubusercontent.com/50844842/226074973-660767d0-4621-4293-aded-e5358344e771.png">


## Checklist

- [x] Code Quality
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation

<!--
Last minute questions to consider -- if the answer is 'yes' to any of these,
please make sure to note that above:

- Does this change require an update to any other applications or third-party libraries?
- Is this change blocked by anything else?
- Does this change require actions outside this PR? E.g., updating secrets or keys?
-->
